### PR TITLE
Update Tests for Côte d’Ivoire Phone Numbers (#2473)

### DIFF
--- a/src/components/PhoneNumberInput.test.tsx
+++ b/src/components/PhoneNumberInput.test.tsx
@@ -4,7 +4,6 @@ import { fireEvent, render } from '@testing-library/react-native'
 import * as React from 'react'
 import { Platform } from 'react-native'
 import PhoneNumberInput from 'src/components/PhoneNumberInput'
-import { waitFor } from 'src/redux/sagas-helpers'
 import { flushMicrotasksQueue } from 'test/utils'
 
 jest.mock('@celo/react-native-sms-retriever', () => {
@@ -138,22 +137,29 @@ describe('PhoneNumberInput', () => {
     expect(onChange).toHaveBeenCalledWith('(415) 426-5200', '+1')
   })
 
-  it('can read Côte d’Ivoire phone numbers', async () => {
+  it('renders and behaves correctly with Côte d’Ivoire phone numbers', async () => {
+    // mock
+    Platform.OS = 'ios'
+
+    const onChange = jest.fn()
+    const onPressCountry = jest.fn()
     const { getByTestId, getByText } = render(
       <PhoneNumberInput
         label="Phone number"
         country={countries.getCountryByCodeAlpha2('CI')}
         internationalPhoneNumber=""
-        onChange={jest.fn()}
-        onPressCountry={jest.fn()}
+        onChange={onChange}
+        onPressCountry={onPressCountry}
       />
     )
 
-    waitFor(async () => {
-      expect(getByText('🇨🇮')).toBeTruthy()
-      expect(getByTestId('PhoneNumberField').props.placeholder).toBe('00 00 0 00000')
-      fireEvent.changeText(getByTestId('PhoneNumberField'), '21 23 4 56789')
-      expect(getByText('+255 21 23 4 56789')).toBeTruthy()
-    })
+    expect(getByText('🇨🇮')).toBeTruthy()
+    expect(getByTestId('PhoneNumberField').props.placeholder).toBe('00 00 0 00000')
+    fireEvent.press(getByTestId('CountrySelectionButton'))
+    await flushMicrotasksQueue()
+    expect(onPressCountry).toHaveBeenCalled()
+
+    fireEvent.changeText(getByTestId('PhoneNumberField'), '2123456789')
+    expect(onChange).toHaveBeenCalledWith('21 23 4 56789', '+225')
   })
 })


### PR DESCRIPTION
### Description

follow up to [Côte d’Ivoire Phone Number Fix #2471](https://github.com/valora-inc/wallet/pull/2471). Tests were erroneously passing due to an incorrect import of `waitFor`. Adjusted the tests to more accurately reflect behavior and removed the `waitFor` entirely.

### Other changes

N/A

### Tested

Tested by running unit tests locally.


### How others should test

N/A

### Related issues

N/A

### Backwards compatibility

Yes

### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._