### PR TITLE
feat: add transaction history to drawer navigation

### DIFF
--- a/locales/base/translation.json
+++ b/locales/base/translation.json
@@ -1301,13 +1301,5 @@
       "errorMessage": "Account number should be 10 digits long and only contain numbers"
     }
   },
-  "daysAgo": "{{days}} days ago",
-  "servicesList": {
-    "buy": "Deposit",
-    "cico": "Withdraw",
-    "swap": "Swap",
-    "invest": "Invest",
-    "bills": "Pay Bills"
-  },
-  "services": "Services"
+  "transactionHistory": "Transaction History"
 }

--- a/src/navigator/DrawerNavigator.tsx
+++ b/src/navigator/DrawerNavigator.tsx
@@ -65,6 +65,7 @@ import TabNavigator from 'src/navigator/TabNavigator'
 import { default as useSelector } from 'src/redux/useSelector'
 import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
+import TransactionHistory from 'src/transactions/TransactionHistory'
 import Logger from 'src/utils/Logger'
 import { currentAccountSelector } from 'src/web3/selectors'
 
@@ -292,6 +293,11 @@ export default function DrawerNavigator() {
         name={Screens.Support}
         component={Support}
         options={{ title: t('help'), drawerIcon: Help }}
+      />
+      <Drawer.Screen
+        name={Screens.TransactionHistory}
+        component={TransactionHistory}
+        options={{ title: t('history'), drawerIcon: Home }}
       />
     </Drawer.Navigator>
   )

--- a/src/navigator/HomeStackNavigator.tsx
+++ b/src/navigator/HomeStackNavigator.tsx
@@ -1,6 +1,5 @@
 import { createStackNavigator } from '@react-navigation/stack'
 import React from 'react'
-import { useTranslation } from 'react-i18next'
 import WalletHome from 'src/home/WalletHome'
 import { headerWithBackButton, noHeader } from 'src/navigator/Headers'
 import { Screens } from 'src/navigator/Screens'
@@ -11,7 +10,6 @@ const TAG = 'HomeStackNavigatorService'
 const Home = createStackNavigator()
 
 export default function HomeStackNavigator() {
-  const { t } = useTranslation()
   return (
     <Home.Navigator initialRouteName={Screens.WalletHome}>
       <Home.Screen name={Screens.WalletHome} component={WalletHome} options={noHeader} />

--- a/src/navigator/Screens.tsx
+++ b/src/navigator/Screens.tsx
@@ -84,6 +84,7 @@ export enum Screens {
   TabNavigation = 'TabNavigator',
   TokenBalances = 'TokenBalances',
   TransactionDetailsScreen = 'TransactionDetailsScreen',
+  TransactionHistory = 'TransactionHistory',
   TransactionReview = 'TransactionReview',
   TransakScreen = 'TransakScreen',
   UpgradeScreen = 'UpgradeScreen',

--- a/src/navigator/types.tsx
+++ b/src/navigator/types.tsx
@@ -277,6 +277,7 @@ export type StackParamList = {
   [Screens.TransactionDetailsScreen]: {
     transaction: TokenTransaction
   }
+  [Screens.TransactionHistory]: undefined
   [Screens.TransactionReview]: {
     reviewProps: ReviewProps
     confirmationProps: TransferConfirmationCardProps | ExchangeConfirmationCardProps

--- a/src/transactions/TransactionHistory.tsx
+++ b/src/transactions/TransactionHistory.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { StyleSheet, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import DrawerTopBar from 'src/navigator/DrawerTopBar'
+import fontStyles from 'src/styles/fonts'
+import TransactionFeed from 'src/transactions/feed/TransactionFeed'
+
+function TransactionHistory() {
+  const { t } = useTranslation()
+
+  const topBarTitle = () => <Text style={styles.title}>{t('history')}</Text>
+
+  return (
+    <SafeAreaView>
+      <DrawerTopBar middleElement={topBarTitle()} />
+      <TransactionFeed />
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  title: {
+    ...fontStyles.navigationHeader,
+  },
+})
+
+export default TransactionHistory


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

* Create a Transaction History screen to the Drawer Navigation
* Should function exactly the same as Transaction Feed on Wallet Home

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._