### PR TITLE
Branding sync keeps images up to date with Kolektivo assets

### DIFF
--- a/scripts/sync_branding.sh
+++ b/scripts/sync_branding.sh
@@ -44,6 +44,7 @@ if [[ "$branding" == "kolektivo" ]]; then
     echo "Couldn't clone private branding. Will use default branding."
     branding=celo
   else
+    branding=celo
     pushd "branding/$branding"
     git pull
     popd

--- a/scripts/sync_branding.sh
+++ b/scripts/sync_branding.sh
@@ -40,7 +40,7 @@ fi
 if [[ "$branding" == "kolektivo" ]]; then
   # prevents git from asking credentials
   export GIT_TERMINAL_PROMPT=0
-  if [[ ! -e branding/kolektivo ]] && ! git clone git@github.com:zed-io/kolektivo-branding.git branding/kolektivo ; then
+  if [[ ! -e branding/kolektivo ]] && ! git clone git@github.com:zed-io/kolektivo-branding.git branding/celo ; then
     echo "Couldn't clone private branding. Will use default branding."
     branding=celo
   else

--- a/scripts/sync_branding.sh
+++ b/scripts/sync_branding.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Flags:
 # -b (Optional): Name of the branding to use: celo or valora (default)
 
-branding=valora
+branding=kolektivo
 while getopts 'b:' flag; do
   case "${flag}" in
     b) branding="$OPTARG" ;;
@@ -40,7 +40,7 @@ fi
 if [[ "$branding" == "kolektivo" ]]; then
   # prevents git from asking credentials
   export GIT_TERMINAL_PROMPT=0
-  if [[ ! -e branding/kolektivo ]] && ! git clone git@github.com:zed.io/kolektivo-branding.git branding/kolektivo ; then
+  if [[ ! -e branding/kolektivo ]] && ! git clone git@github.com:zed-io/kolektivo-branding.git branding/kolektivo ; then
     echo "Couldn't clone private branding. Will use default branding."
     branding=celo
   else


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

Updated the `sync_branding.sh` script that pulls from `zed-io/kolektivo-branding` so that it will include update icons. This is done because the post-install script will otherwise revert them.

### Other changes

_Describe any minor or "drive-by" changes here._

None.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

Pull `develop` and run `yarn install`, the assets used should reflect the updated white Kolektivo test-flight icon. 

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._