### PR TITLE
fix: (KW 84) Add a 'Done' key for swap amount input

### DIFF
--- a/src/swap/ExchangeAssetField.tsx
+++ b/src/swap/ExchangeAssetField.tsx
@@ -27,7 +27,7 @@ const ExchangeAssetField = ({ asset, direction, style }: ExchangeFieldProps) => 
     if (!Number.isNaN(res)) dispatch(setSwapAssetAmount(res, direction))
     else dispatch(setSwapAssetAmount(0, direction))
   }
-  
+
   return (
     <View style={styles.assetRow} {...style}>
       <View style={styles.inputRow}>
@@ -40,6 +40,7 @@ const ExchangeAssetField = ({ asset, direction, style }: ExchangeFieldProps) => 
             testID={`${direction}/Amount`}
             value={`${amount}`}
             keyboardType={'decimal-pad'}
+            returnKeyType="done"
           />
           <Text style={[styles.localFiat, styles.controlled]}>$ {Number(0).toPrecision(3)}</Text>
         </View>


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

On mobile, it is impossible to close the decimal pad keyboard, this change adds a 'done' button to the native keyboard so that the user can complete once they are done.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._