### PR TITLE
(KW 130) fixed android not building due to sentry

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,9 +92,9 @@ project.ext.envConfigFiles = [
     "": ".env.alfajoresdev", // Fallback
 ]
 
-project.ext.sentryCli = [
-   // logLevel: "debug"
-]
+// project.ext.sentryCli = [
+//    logLevel: "debug"
+// ]
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 apply from: "../../node_modules/react-native/react.gradle"
@@ -106,9 +106,9 @@ apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"
  */
 def isDetoxTestBuild = Boolean.valueOf(project.properties['isDetoxBuild'] ?: 'false')
 
-if (!isDetoxTestBuild) {
-  // apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
-}
+// if (!isDetoxTestBuild) {
+//    apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
+// }
 
 /**
  * Set this to true to create two separate APKs instead of one:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,7 +93,7 @@ project.ext.envConfigFiles = [
 ]
 
 project.ext.sentryCli = [
-    logLevel: "debug"
+   // logLevel: "debug"
 ]
 
 apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
@@ -107,7 +107,7 @@ apply from: "../../node_modules/react-native-code-push/android/codepush.gradle"
 def isDetoxTestBuild = Boolean.valueOf(project.properties['isDetoxBuild'] ?: 'false')
 
 if (!isDetoxTestBuild) {
-  apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
+  // apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 }
 
 /**

--- a/android/app/src/main/java/org/celo/mobile/MainApplication.java
+++ b/android/app/src/main/java/org/celo/mobile/MainApplication.java
@@ -16,7 +16,6 @@ import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
 import com.microsoft.codepush.react.CodePush;
 import com.swmansion.reanimated.ReanimatedJSIModulePackage;
-import io.sentry.react.RNSentryPackage;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
### Description

Android did not build because of sentry being enabled even though its disabled.

Sentry has been removed from android

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

1. sync branding
2. run ./gradlew bundleRelease in the android folder.

It should not fail on sentryUpload error. Instead, it should fail cause of missing signing keys. 

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._