### PR TITLE
(KW147) Allow user to open maps for directions to the Vendor

### DIFF
--- a/src/app/ErrorMessages.ts
+++ b/src/app/ErrorMessages.ts
@@ -92,4 +92,5 @@ export enum ErrorMessages {
   SUPERCHARGE_FETCH_REWARDS_FAILED = 'superchargeFetchRewardsFailed',
   SUPERCHARGE_CLAIM_FAILED = 'superchargeClaimFailure',
   ADD_FIAT_ACCOUNT_RESOURCE_EXIST = 'fiatDetailsScreen.addFiatAccountResourceExist',
+  FAILED_OPEN_DIRECTION = 'failedOpeningDirections',
 }

--- a/src/icons/Pin.tsx
+++ b/src/icons/Pin.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import Svg, { G, Path } from 'react-native-svg'
 import colors from 'src/styles/colors'
 
-function Pin({ size = 25, color = colors.dark as string }) {
+function Pin({ size = 25, color = colors.gray5 as string }) {
   return (
     <Svg width={size} height={size} viewBox="0 0 95 107">
       <G id="Kolektivo" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -43,6 +43,17 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
   } = vendor
   const { location } = vendor as VendorWithLocation
   const dispatch = useDispatch()
+
+  const handleOpenMap = (): void => {
+    try {
+      initiateDirection({ title, coordinate: location, building_number, street, city })
+    } catch (error) {
+      Logger.warn('Directions', error)
+      dispatch(showError(ErrorMessages.FAILED_OPEN_DIRECTION))
+      return
+    }
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.sheetHeader}>
@@ -64,17 +75,7 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
             </TouchableOpacity>
           )}
           {((location.latitude !== 0 && location.longitude !== 0) || street) && (
-            <TouchableOpacity
-              onPress={() => {
-                try {
-                  initiateDirection({ title, coordinate: location, building_number, street, city })
-                } catch (error) {
-                  Logger.warn('Directions', error)
-                  dispatch(showError(ErrorMessages.FAILED_OPEN_DIRECTION))
-                  return
-                }
-              }}
-            >
+            <TouchableOpacity onPress={handleOpenMap}>
               <Directions />
             </TouchableOpacity>
           )}

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -25,7 +25,18 @@ type Props = {
 }
 
 const VendorDetails = ({ vendor, close, action }: Props) => {
-  const { title, subtitle, address, siteURI, description, tags, logoURI, phoneNumber } = vendor
+  const {
+    title,
+    subtitle,
+    street,
+    building_number,
+    city,
+    siteURI,
+    description,
+    tags,
+    logoURI,
+    phoneNumber,
+  } = vendor
   const { location } = vendor as VendorWithLocation
   return (
     <View style={styles.container}>
@@ -48,7 +59,11 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
             </TouchableOpacity>
           )}
           {location && (
-            <TouchableOpacity onPress={() => initiateDirection({ coordinate: location })}>
+            <TouchableOpacity
+              onPress={() =>
+                initiateDirection({ title, coordinate: location, building_number, street, city })
+              }
+            >
               <Directions />
             </TouchableOpacity>
           )}
@@ -64,10 +79,10 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
           )}
         </View>
         <View style={styles.furtherDetailsRow}>
-          {address && (
+          {street && (
             <View>
               <Pin />
-              <Text>{address}</Text>
+              <Text>{`${street} ${building_number}, ${city}`}</Text>
             </View>
           )}
         </View>

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -58,7 +58,7 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
               <Phone />
             </TouchableOpacity>
           )}
-          {location && (
+          {((location.latitude !== 0 && location.longitude !== 0) || street) && (
             <TouchableOpacity
               onPress={() =>
                 initiateDirection({ title, coordinate: location, building_number, street, city })
@@ -81,7 +81,7 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
         <View style={styles.furtherDetailsRow}>
           {street && (
             <View style={styles.streetContainer}>
-              <Pin style={styles.streetPin} />
+              <Pin />
               <Text style={styles.street}>{`${street} ${building_number}, ${city}`}</Text>
             </View>
           )}

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -80,9 +80,9 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
         </View>
         <View style={styles.furtherDetailsRow}>
           {street && (
-            <View>
-              <Pin />
-              <Text>{`${street} ${building_number}, ${city}`}</Text>
+            <View style={styles.streetContainer}>
+              <Pin style={styles.streetPin} />
+              <Text style={styles.street}>{`${street} ${building_number}, ${city}`}</Text>
             </View>
           )}
         </View>
@@ -171,6 +171,25 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   furtherDetailsRow: {},
+  streetContainer: {
+    ...fontStyles.regular,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginVertical: 20,
+  },
+  street: {
+    ...fontStyles.regular,
+    color: colors.gray5,
+    textAlign: 'justify',
+    fontSize: 14,
+  },
+  streetPin: {
+    ...fontStyles.regular,
+    textAlign: 'justify',
+    fontSize: 14,
+  },
   tags: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -2,6 +2,9 @@ import { map } from 'lodash'
 import React from 'react'
 import { Image, StyleSheet, Text, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
+import { useDispatch } from 'react-redux'
+import { showError } from 'src/alert/actions'
+import { ErrorMessages } from 'src/app/ErrorMessages'
 import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
 import Touchable from 'src/components/Touchable'
 import Directions from 'src/icons/Directions'
@@ -16,6 +19,7 @@ import colors from 'src/styles/colors'
 import fontStyles from 'src/styles/fonts'
 import variables from 'src/styles/variables'
 import { navigateToURI } from 'src/utils/linking'
+import Logger from 'src/utils/Logger'
 import { Vendor, VendorWithLocation } from 'src/vendors/types'
 
 type Props = {
@@ -38,6 +42,7 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
     phoneNumber,
   } = vendor
   const { location } = vendor as VendorWithLocation
+  const dispatch = useDispatch()
   return (
     <View style={styles.container}>
       <View style={styles.sheetHeader}>
@@ -60,9 +65,15 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
           )}
           {((location.latitude !== 0 && location.longitude !== 0) || street) && (
             <TouchableOpacity
-              onPress={() =>
-                initiateDirection({ title, coordinate: location, building_number, street, city })
-              }
+              onPress={() => {
+                try {
+                  initiateDirection({ title, coordinate: location, building_number, street, city })
+                } catch (error) {
+                  Logger.warn('Directions', error)
+                  dispatch(showError(ErrorMessages.FAILED_OPEN_DIRECTION))
+                  return
+                }
+              }}
             >
               <Directions />
             </TouchableOpacity>
@@ -82,7 +93,9 @@ const VendorDetails = ({ vendor, close, action }: Props) => {
           {street && (
             <View style={styles.streetContainer}>
               <Pin />
-              <Text style={styles.street}>{`${street} ${building_number}, ${city}`}</Text>
+              <Text style={styles.street}>{`${street} ${building_number}${
+                city ? `,${city}` : ''
+              }`}</Text>
             </View>
           )}
         </View>

--- a/src/vendors/VendorDetails.tsx
+++ b/src/vendors/VendorDetails.tsx
@@ -185,11 +185,6 @@ const styles = StyleSheet.create({
     textAlign: 'justify',
     fontSize: 14,
   },
-  streetPin: {
-    ...fontStyles.regular,
-    textAlign: 'justify',
-    fontSize: 14,
-  },
   tags: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/src/vendors/types.ts
+++ b/src/vendors/types.ts
@@ -10,6 +10,9 @@ export type Vendor = {
   currencies: Array<string>
   address?: string
   phoneNumber?: string
+  street: string
+  building_number: string
+  city: string
 }
 
 export type VendorWithLocation = Vendor & {

--- a/src/vendors/utils.ts
+++ b/src/vendors/utils.ts
@@ -26,6 +26,9 @@ export const formatVendors = (vendorObject: any): Vendors => {
         latitude,
         longitude,
         phone_number,
+        street,
+        building_number,
+        city,
       } = v.attributes
       return {
         [name]: {
@@ -35,6 +38,9 @@ export const formatVendors = (vendorObject: any): Vendors => {
           title: name,
           subtitle: subtitle,
           phoneNumber: phone_number,
+          street: street,
+          building_number: building_number,
+          city: city,
           location: {
             // The Latitude and Longitude attributes cannot be null or undefined
             // in the Android environment.


### PR DESCRIPTION
### Description

This PR allows users to open a vendor on their native map using ether coordinates or the address the vendor has provided.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

Open the map on the Kolektivo wallet, press on a vendor clicks on the directions icon.
It should ether open the device's native map using coordinates or the vendor's address.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

![image](https://user-images.githubusercontent.com/12153793/185257712-cd953cdb-000b-4f46-9010-8e3f225208d5.png)

![image](https://user-images.githubusercontent.com/12153793/185257742-fe73ddaa-d4a8-47c7-9ade-4b1dbe545f5f.png)
