### PR TITLE
(KW 157) Android app crashed during build #43

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath 'com.google.gms:google-services:4.3.2'
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlinVersion"
 


### PR DESCRIPTION
### Description

Android app is unable to build to to some error.

In project 'app' a resolved Google Play services library dependency depends on another at an exact version (e.g. "[1.3.1 ,2.3]", but isn't being resolved to that version. Behavior exhibited by the library will be unknown. Dependency failing: com.nimbusds:nimbus-jose-jwt:5.1 -> net.minidev:json-smart@[1.3.1,2.3], but json-smart version was 2 .3.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

Download the google-services.json from firebase, add it to the android/app folder.
And run the yarn dev:android command.

The build shouldn't fail now.

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._