### PR TITLE
feat: (KW-180) Allow surfacing Food Forests on the Map Interface

### DIFF
--- a/src/app/reducers.ts
+++ b/src/app/reducers.ts
@@ -4,6 +4,7 @@ import { Actions, ActionTypes, AppState } from 'src/app/actions'
 import { Dapp, SuperchargeButtonType } from 'src/app/types'
 import { SuperchargeTokenConfig } from 'src/consumerIncentives/types'
 import { REMOTE_CONFIG_VALUES_DEFAULTS } from 'src/firebase/remoteConfigValuesDefaults'
+import { MapCategory } from 'src/map/constants'
 import { PaymentDeepLinkHandler } from 'src/merchantPayment/types'
 import { Screens } from 'src/navigator/Screens'
 import { getRehydratePayload, REHYDRATE, RehydrateAction } from 'src/redux/persist-helper'
@@ -67,6 +68,7 @@ export interface State {
   skipProfilePicture: boolean
   finclusiveUnsupportedStates: string[]
   celoWithdrawalEnabledInExchange: boolean
+  mapCategory: MapCategory
 }
 
 const initialState = {
@@ -115,6 +117,7 @@ const initialState = {
   skipProfilePicture: REMOTE_CONFIG_VALUES_DEFAULTS.skipProfilePicture,
   finclusiveUnsupportedStates: REMOTE_CONFIG_VALUES_DEFAULTS.finclusiveUnsupportedStates.split(','),
   celoWithdrawalEnabledInExchange: REMOTE_CONFIG_VALUES_DEFAULTS.celoWithdrawalEnabledInExchange,
+  mapCategory: MapCategory.All,
 }
 
 export const appReducer = (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -86,7 +86,7 @@ export default React.memo(function Button(props: ButtonProps) {
               <Text
                 maxFontSizeMultiplier={1}
                 accessibilityLabel={accessibilityLabel}
-                style={{ ...fontStyles.regular600, color: textColor }}
+                style={{ ...getFontStyle(size), color: textColor }}
               >
                 {text}
               </Text>
@@ -115,8 +115,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   tiny: {
-    height: 40,
-    minWidth: 40,
+    height: 28,
+    minWidth: 32,
+    paddingVertical: 3,
+    paddingHorizontal: 16,
   },
   small: {
     height: 40,
@@ -131,6 +133,21 @@ const styles = StyleSheet.create({
     flexGrow: 1,
   },
 })
+
+function getFontStyle(size: BtnSizes | undefined) {
+  let fontStyle
+  switch (size) {
+    case BtnSizes.SMALL || BtnSizes.TINY: {
+      fontStyle = { ...fontStyles.small }
+      break
+    }
+    default: {
+      fontStyle = { ...fontStyles.regular600 }
+      break
+    }
+  }
+  return { ...fontStyle }
+}
 
 function getColors(type: BtnTypes, disabled: boolean | undefined) {
   let textColor
@@ -183,7 +200,13 @@ function getStyle(
 ) {
   switch (size) {
     case BtnSizes.TINY:
-      return { ...styles.button, ...styles.buttonPadding, ...styles.tiny, backgroundColor, opacity }
+      return {
+        ...styles.button,
+        ...styles.buttonPadding,
+        ...styles.tiny,
+        backgroundColor,
+        opacity,
+      }
     case BtnSizes.SMALL:
       return {
         ...styles.button,
@@ -193,7 +216,13 @@ function getStyle(
         opacity,
       }
     case BtnSizes.FULL:
-      return { ...styles.button, ...styles.buttonPadding, ...styles.full, backgroundColor, opacity }
+      return {
+        ...styles.button,
+        ...styles.buttonPadding,
+        ...styles.full,
+        backgroundColor,
+        opacity,
+      }
     default:
       return {
         ...styles.button,

--- a/src/map/MapBottomSheet.tsx
+++ b/src/map/MapBottomSheet.tsx
@@ -1,7 +1,9 @@
 import BottomSheet, { BottomSheetFlatList } from '@gorhom/bottom-sheet'
-import React, { useRef } from 'react'
-import { ListRenderItemInfo, StyleSheet, Text } from 'react-native'
+import React, { useCallback, useRef } from 'react'
+import { ListRenderItemInfo, StyleSheet } from 'react-native'
 import { useDispatch, useSelector } from 'react-redux'
+import { MapCategory } from 'src/map/constants'
+import MapSheetHandle from 'src/map/MapFilters'
 import fontStyles from 'src/styles/fonts'
 import { setCurrentVendor } from 'src/vendors/actions'
 import { currentVendorSelector, vendorsSelector } from 'src/vendors/selector'
@@ -30,9 +32,18 @@ const MapBottomSheet = () => {
     )
   }
 
+  const renderHandle = useCallback(
+    (props) => <MapSheetHandle title={MapCategory.All} {...props} />,
+    []
+  )
+
   return (
-    <BottomSheet ref={bottomSheetRef} index={0} snapPoints={snapPoints}>
-      <Text style={styles.header}>{!currentVendor && `Vendors`}</Text>
+    <BottomSheet
+      ref={bottomSheetRef}
+      index={0}
+      snapPoints={snapPoints}
+      handleComponent={renderHandle}
+    >
       {!currentVendor && (
         <BottomSheetFlatList
           data={vendors}
@@ -53,10 +64,6 @@ const MapBottomSheet = () => {
 }
 
 const styles = StyleSheet.create({
-  header: {
-    marginHorizontal: 16,
-    ...fontStyles.h1,
-  },
   innerContainer: {},
 })
 

--- a/src/map/MapFilters.tsx
+++ b/src/map/MapFilters.tsx
@@ -1,0 +1,158 @@
+import { BottomSheetHandleProps } from '@gorhom/bottom-sheet'
+import { keysIn } from 'lodash'
+import React, { memo, useMemo } from 'react'
+import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native'
+import Animated, {
+  Extrapolate,
+  interpolate,
+  useAnimatedStyle,
+  useDerivedValue,
+} from 'react-native-reanimated'
+import { toRad } from 'react-native-redash'
+import Button, { BtnSizes, BtnTypes } from 'src/components/Button'
+import { MapCategory } from 'src/map/constants'
+import { transformOrigin } from 'src/utils/transform'
+
+interface CustomHandleProps extends BottomSheetHandleProps {
+  title: string
+  style?: StyleProp<ViewStyle>
+}
+
+const MapSheetHandle: React.FC<CustomHandleProps> = ({ title, style, animatedIndex }) => {
+  //#region animations
+
+  const indicatorTransformOriginY = useDerivedValue(() =>
+    interpolate(animatedIndex.value, [0, 1, 2], [-1, 0, 1], Extrapolate.CLAMP)
+  )
+  //#endregion
+
+  //#region styles
+  const containerStyle = useMemo(() => [styles.container, style], [style])
+  const containerAnimatedStyle = useAnimatedStyle(() => {
+    const borderTopRadius = interpolate(animatedIndex.value, [1, 2], [20, 0], Extrapolate.CLAMP)
+    return {
+      borderTopLeftRadius: borderTopRadius,
+      borderTopRightRadius: borderTopRadius,
+    }
+  })
+  const leftIndicatorStyle = useMemo(
+    () => ({
+      ...styles.indicator,
+      ...styles.leftIndicator,
+    }),
+    []
+  )
+  const leftIndicatorAnimatedStyle = useAnimatedStyle(() => {
+    const leftIndicatorRotate = interpolate(
+      animatedIndex.value,
+      [0, 1, 2],
+      [toRad(-30), 0, toRad(30)],
+      Extrapolate.CLAMP
+    )
+    return {
+      transform: transformOrigin(
+        { x: 0, y: indicatorTransformOriginY.value },
+        {
+          rotate: `${leftIndicatorRotate}rad`,
+        },
+        {
+          translateX: -5,
+        }
+      ),
+    }
+  })
+  const rightIndicatorStyle = useMemo(
+    () => ({
+      ...styles.indicator,
+      ...styles.rightIndicator,
+    }),
+    []
+  )
+  const rightIndicatorAnimatedStyle = useAnimatedStyle(() => {
+    const rightIndicatorRotate = interpolate(
+      animatedIndex.value,
+      [0, 1, 2],
+      [toRad(30), 0, toRad(-30)],
+      Extrapolate.CLAMP
+    )
+    return {
+      transform: transformOrigin(
+        { x: 0, y: indicatorTransformOriginY.value },
+        {
+          rotate: `${rightIndicatorRotate}rad`,
+        },
+        {
+          translateX: 5,
+        }
+      ),
+    }
+  })
+  //#endregion
+
+  const renderFilters = () => {
+    return (
+      <>
+        {keysIn(MapCategory).map((cat) => {
+          return (
+            <Button text={cat} size={BtnSizes.SMALL} type={BtnTypes.SECONDARY} onPress={() => {}} />
+          )
+        })}
+      </>
+    )
+  }
+
+  // render
+  return (
+    <Animated.View
+      style={[containerStyle, containerAnimatedStyle]}
+      renderToHardwareTextureAndroid={true}
+    >
+      <View style={[styles.headerFilter, styles.flex]}>{renderFilters()}</View>
+      <Animated.View style={[leftIndicatorStyle, leftIndicatorAnimatedStyle]} />
+      <Animated.View style={[rightIndicatorStyle, rightIndicatorAnimatedStyle]} />
+      <Text style={styles.title}>{title}</Text>
+    </Animated.View>
+  )
+}
+
+export default memo(MapSheetHandle)
+
+const styles = StyleSheet.create({
+  container: {
+    alignContent: 'center',
+    alignItems: 'center',
+    paddingBottom: 12,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: 'rgba(0,0,0,0.125)',
+    zIndex: 99999,
+  },
+  indicator: {
+    marginTop: 10,
+    position: 'absolute',
+    width: 10,
+    height: 4,
+    backgroundColor: '#999',
+  },
+  leftIndicator: {
+    borderTopStartRadius: 2,
+    borderBottomStartRadius: 2,
+  },
+  rightIndicator: {
+    borderTopEndRadius: 2,
+    borderBottomEndRadius: 2,
+  },
+  title: {
+    marginTop: 26,
+    fontSize: 20,
+    lineHeight: 20,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
+  flex: {
+    flexDirection: 'row',
+  },
+  headerFilter: {
+    marginTop: -50,
+  },
+})

--- a/src/map/MapScreen.tsx
+++ b/src/map/MapScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useRef } from 'react'
 import { Platform, StyleSheet } from 'react-native'
 import MapView from 'react-native-maps'
 import Animated from 'react-native-reanimated'
@@ -47,8 +47,8 @@ const MapScreen = () => {
       >
         {vendors && vendorLocationMarkers()}
       </MapView>
-      <MapBottomSheet />
       <DrawerTopBar scrollPosition={scrollPosition} />
+      <MapBottomSheet />
     </SafeAreaView>
   )
 }

--- a/src/map/constants.ts
+++ b/src/map/constants.ts
@@ -2,6 +2,12 @@ import { LatLng, Region } from 'react-native-maps'
 
 export const BASE_TAG = 'MapScreen'
 
+export enum MapCategory {
+  All = 'All',
+  Vendor = 'Vendor',
+  FoodForest = 'FoodForest',
+}
+
 export const LOCALE_LATLNG: LatLng = {
   latitude: 12.1696,
   longitude: -68.99,

--- a/src/utils/transform.ts
+++ b/src/utils/transform.ts
@@ -1,0 +1,11 @@
+//@ts-ignore
+export const transformOrigin = ({ x, y }, ...transformations) => {
+  'worklet'
+  return [
+    { translateX: x },
+    { translateY: y },
+    ...transformations,
+    { translateX: x * -1 },
+    { translateY: y * -1 },
+  ]
+}


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

The map component currently shows only vendors. This update adds filter buttons on the top of the map sheet that can be clicked to view Vendors or Food Forests (etc.)

### Other changes

_Describe any minor or "drive-by" changes here._

Adds a `map` reducer that handles general state management for the map's supporting data (e.g. toggling map categories, setting map search queries)

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

This item will be merged into #58 

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

This update is backwards compatible as it is not destructive to the shape of the redux store, and does not introduce any new packages.