### PR TITLE
(KW-195) Add Bidali Support for purchasing mobile top-up 

### DIFF
--- a/src/fiatExchanges/BidaliScreen.test.tsx
+++ b/src/fiatExchanges/BidaliScreen.test.tsx
@@ -13,14 +13,14 @@ const mockScreenProps = getMockStackScreenProps(Screens.BidaliScreen, {
 
 declare global {
   interface Window {
-    valora: any
+    bidaliProvider: any
   }
 }
 
 describe(BidaliScreen, () => {
   beforeEach(() => {
     // Reset injected JS effect
-    window.valora = undefined
+    window.bidaliProvider = undefined
   })
 
   it('renders correctly when no phone number is provided', () => {
@@ -39,15 +39,16 @@ describe(BidaliScreen, () => {
     expect(webView).toBeDefined()
     // eslint-disable-next-line no-eval
     expect(eval(webView.props.injectedJavaScriptBeforeContentLoaded)).toBe(true)
-    expect(window.valora).toMatchInlineSnapshot(`
+    expect(window.bidaliProvider).toMatchInlineSnapshot(`
       Object {
+        "name": "kolektivo"
         "balances": Object {
           "CEUR": "5",
           "CUSD": "10",
         },
         "onPaymentRequest": [Function],
         "openUrl": [Function],
-        "paymentCurrency": "CUSD",
+        "paymentCurrencies": ["CUSD"],
         "phoneNumber": null,
       }
     `)
@@ -68,15 +69,16 @@ describe(BidaliScreen, () => {
     expect(webView).toBeDefined()
     // eslint-disable-next-line no-eval
     expect(eval(webView.props.injectedJavaScriptBeforeContentLoaded)).toBe(true)
-    expect(window.valora).toMatchInlineSnapshot(`
+    expect(window.bidaliProvider).toMatchInlineSnapshot(`
       Object {
+        "name": "kolektivo"
         "balances": Object {
           "CEUR": "5",
           "CUSD": "10",
         },
         "onPaymentRequest": [Function],
         "openUrl": [Function],
-        "paymentCurrency": "CUSD",
+        "paymentCurrencies": ["CUSD"],
         "phoneNumber": "+14155556666",
       }
     `)
@@ -101,16 +103,17 @@ describe(BidaliScreen, () => {
     expect(webView).toBeDefined()
     // eslint-disable-next-line no-eval
     expect(eval(webView.props.injectedJavaScriptBeforeContentLoaded)).toBe(true)
-    // `paymentCurrency` is CEUR here because it has the highest balance in the local currency
-    expect(window.valora).toMatchInlineSnapshot(`
+    // `paymentCurrencies` is CEUR here because it has the highest balance in the local currency
+    expect(window.bidaliProvider).toMatchInlineSnapshot(`
       Object {
+        "name": "kolektivo"
         "balances": Object {
           "CEUR": "9",
           "CUSD": "10",
         },
         "onPaymentRequest": [Function],
         "openUrl": [Function],
-        "paymentCurrency": "CEUR",
+        "paymentCurrencies": ["CEUR"],
         "phoneNumber": "+14155556666",
       }
     `)

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -42,8 +42,9 @@ function useInitialJavaScript(
     // When a new url needs to be open (currently for FAQ, Terms of Service), `openUrl` is called by Bidali.
     // See also the comment in the `onMessage` handler
     setInitialJavaScript(`
-      window.valora = {
-        paymentCurrency: "${currency.toUpperCase()}",
+      window.bidaliProvider = {
+        name: 'kolektivo'
+        paymentCurrencies: ["${currency.toUpperCase()}"],
         phoneNumber: ${JSON.stringify(e164PhoneNumber)},
         balances: ${jsonBalances},
         onPaymentRequest: function (paymentRequest) {
@@ -87,10 +88,10 @@ function BidaliScreen({ route, navigation }: Props) {
         // These 2 callbacks needs to be called to notify Bidali of the status of the payment request
         // so it can update the WebView accordingly.
         const onPaymentSent = () => {
-          webViewRef.current?.injectJavaScript(`window.valora.paymentSent();`)
+          webViewRef.current?.injectJavaScript(`window.bidaliProvider.paymentSent();`)
         }
         const onCancelled = () => {
-          webViewRef.current?.injectJavaScript(`window.valora.paymentCancelled();`)
+          webViewRef.current?.injectJavaScript(`window.bidaliProvider.paymentCancelled();`)
         }
         dispatch(
           bidaliPaymentRequested(
@@ -138,7 +139,7 @@ function BidaliScreen({ route, navigation }: Props) {
   // Update balances when they change
   useEffect(() => {
     webViewRef.current?.injectJavaScript(`
-      window.valora.balances = ${jsonBalances}
+      window.bidaliProvider.balances = ${jsonBalances}
     `)
   }, [jsonBalances])
 

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -43,7 +43,7 @@ function useInitialJavaScript(
     // See also the comment in the `onMessage` handler
     setInitialJavaScript(`
       window.bidaliProvider = {
-        name: 'kolektivo'
+        name: 'kolektivo',
         paymentCurrencies: ["${currency.toLowerCase()}"],
         phoneNumber: ${JSON.stringify(e164PhoneNumber)},
         balances: ${jsonBalances},

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -44,7 +44,7 @@ function useInitialJavaScript(
     setInitialJavaScript(`
       window.bidaliProvider = {
         name: 'kolektivo'
-        paymentCurrencies: ["${currency.toUpperCase()}"],
+        paymentCurrencies: ["${currency.toLowerCase()}"],
         phoneNumber: ${JSON.stringify(e164PhoneNumber)},
         balances: ${jsonBalances},
         onPaymentRequest: function (paymentRequest) {
@@ -120,7 +120,7 @@ function BidaliScreen({ route, navigation }: Props) {
         // Maps supported currencies to an object with their balance
         // Example: [cUSD, cEUR] to { CUSD: X, CEUR: Y }
         Object.fromEntries(
-          BIDALI_CURRENCIES.map((currency) => [currency.toUpperCase(), balances[currency]])
+          BIDALI_CURRENCIES.map((currency) => [currency.toLowerCase(), balances[currency]])
         )
       ),
     [balances]

--- a/src/fiatExchanges/BidaliScreen.tsx
+++ b/src/fiatExchanges/BidaliScreen.tsx
@@ -84,7 +84,7 @@ function BidaliScreen({ route, navigation }: Props) {
     const { method, data } = JSON.parse(event.nativeEvent.data)
     switch (method) {
       case 'onPaymentRequest':
-        const { amount, address, currency, description, chargeId } = data
+        const { amount, address, symbol, description, chargeId } = data
         // These 2 callbacks needs to be called to notify Bidali of the status of the payment request
         // so it can update the WebView accordingly.
         const onPaymentSent = () => {
@@ -97,7 +97,7 @@ function BidaliScreen({ route, navigation }: Props) {
           bidaliPaymentRequested(
             address,
             amount,
-            currency,
+            symbol,
             description,
             chargeId,
             onPaymentSent,

--- a/src/services/Services.ts
+++ b/src/services/Services.ts
@@ -1,8 +1,9 @@
 import { Dapp } from 'src/app/types'
 import MobileTopUp from 'src/icons/MobileTopUp'
 import Swap from 'src/icons/Swap'
+import { Screens } from 'src/navigator/Screens'
 
-const Dapps: Dapp[] = [
+export const ServiceDapps: Dapp[] = [
   {
     id: 'symmetric-dex',
     categoryId: 'swap',
@@ -27,12 +28,12 @@ export const CoreServices = [
   {
     title: 'servicesList.swap',
     icon: Swap,
-    dapp: Dapps[0],
+    dapp: ServiceDapps[0],
   },
   {
     title: 'servicesList.mobileTopUp',
     icon: MobileTopUp,
-    dapp: Dapps[1],
+    screen: Screens.BidaliScreen,
   },
 ]
 

--- a/src/services/WalletServices.tsx
+++ b/src/services/WalletServices.tsx
@@ -5,12 +5,12 @@ import { TouchableOpacity } from 'react-native-gesture-handler'
 import Animated from 'react-native-reanimated'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { FlatGrid } from 'react-native-super-grid'
-import { DappSection } from 'src/app/reducers'
 import useOpenDapp from 'src/dappsExplorer/useOpenDapp'
 import Logo from 'src/icons/Logo'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
-import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
 import useSelector from 'src/redux/useSelector'
+import { useServices } from 'src/services/hooks'
 import { CoreServices } from 'src/services/Services'
 import fontStyles from 'src/styles/fonts'
 
@@ -22,6 +22,7 @@ function WalletServices() {
   const { t } = useTranslation()
 
   const isLoading = useSelector((state) => state.home.loading)
+  const { openBidali } = useServices()
   const { onSelectDapp, ConfirmOpenDappBottomSheet } = useOpenDapp()
   const scrollPosition = useRef(new Animated.Value(0)).current
   const onScroll = Animated.event([{ nativeEvent: { contentOffset: { y: scrollPosition } } }])
@@ -35,10 +36,10 @@ function WalletServices() {
   }
 
   const handleVendorSelect = (item: any) => {
-    if (item.dapp) {
-      onSelectDapp({ ...item.dapp, openedFrom: DappSection.All })
-    } else if (item.screen) {
-      navigate(item.screen)
+    if (item.screen == Screens.BidaliScreen) {
+      openBidali()
+    } else if (item.dapp) {
+      onSelectDapp(item.dapp)
     }
   }
 

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -1,0 +1,13 @@
+import { navigate } from 'src/navigator/NavigationService'
+import { Screens } from 'src/navigator/Screens'
+
+export const useServices = () => {
+  const openBidali = () => {
+    navigate(Screens.BidaliScreen, {
+      currency: undefined,
+    })
+  }
+  return {
+    openBidali,
+  }
+}


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

* Add Bidali URL to `secrets.json` (ask for the credentials) from Bidali
* Modify the WebView `window` javascript payload based on Bidali's provided documentation [here](https://docs.bidali.com/commerce-sdk/react-native) 

### Other changes

_Describe any minor or "drive-by" changes here._

* Move "service opening" logic to a services hook for the future of the unified services screen.

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._

* Unit tests modified for Bidali Screen

### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

[Testnet] The Bidali flow seems to halt E2E at the "Select Payment Method" stage
[Mainnet] Test also on Mainnet, Kolektivo should be visible as a payment method and take the user to the Send screen, however the transaction does not need to be executed.