### PR TITLE
(KW-198) Temporary User Education flow screen design

### DIFF
--- a/src/account/AccountKeyEducation.tsx
+++ b/src/account/AccountKeyEducation.tsx
@@ -5,7 +5,6 @@ import Education, { EducationTopic, EmbeddedNavBar } from 'src/account/Education
 import { OnboardingEvents } from 'src/analytics/Events'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import { BtnTypes } from 'src/components/Button'
-import { accountKey1, accountKey2, accountKey3, accountKey4 } from 'src/images/Images'
 import { noHeader } from 'src/navigator/Headers'
 import { navigate } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
@@ -36,6 +35,7 @@ export default function AccountKeyEducation(props: Props) {
       embeddedNavBar={EmbeddedNavBar.Close}
       stepInfo={steps}
       onFinish={onComplete}
+      experimentalSwiper={true}
       finalButtonText={t('completeEducation')}
       buttonText={t('next')}
       finalButtonType={BtnTypes.PRIMARY}
@@ -53,10 +53,10 @@ function useSteps() {
   return React.useMemo(
     () =>
       [
-        { image: accountKey1, topic: EducationTopic.backup },
-        { image: accountKey2, topic: EducationTopic.backup },
-        { image: accountKey3, topic: EducationTopic.backup },
-        { image: accountKey4, topic: EducationTopic.backup },
+        { image: null, topic: EducationTopic.backup },
+        { image: null, topic: EducationTopic.backup },
+        { image: null, topic: EducationTopic.backup },
+        { image: null, topic: EducationTopic.backup },
       ].map((step, index) => {
         return {
           ...step,

--- a/src/account/Education.tsx
+++ b/src/account/Education.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import { useState } from 'react'
 import {
+  Dimensions,
   Image,
   ImageSourcePropType,
   ScrollView,
@@ -10,6 +11,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated'
 import { NativeSafeAreaViewProps, SafeAreaView } from 'react-native-safe-area-context'
 import Swiper from 'react-native-swiper'
 import { OnboardingEvents } from 'src/analytics/Events'
@@ -17,7 +19,7 @@ import { ScrollDirection } from 'src/analytics/types'
 import ValoraAnalytics from 'src/analytics/ValoraAnalytics'
 import Button, { BtnTypes } from 'src/components/Button'
 import BackChevron from 'src/icons/BackChevron'
-import Logo from 'src/icons/Logo'
+import Logo, { LogoTypes } from 'src/icons/Logo'
 import Times from 'src/icons/Times'
 import DrawerTopBar from 'src/navigator/DrawerTopBar'
 import { navigateBack } from 'src/navigator/NavigationService'
@@ -133,6 +135,23 @@ const Education = ({
     }
   }
 
+  const progress = useSharedValue(0)
+  const width = Dimensions.get('window').width
+
+  const logoAnimatedStyle = useAnimatedStyle(() => {
+    const padding = 24
+    const start = 0 + padding
+    const end = width - padding
+    const distance = Math.abs(start - end)
+    return {
+      transform: [{ translateX: progress.value * (distance / 4) }],
+    }
+  }, [progress.value])
+
+  React.useEffect(() => {
+    progress.value = withTiming(step)
+  }, [step])
+
   const renderEmbeddedNavBar = () => {
     const color = experimentalSwiper ? colors.light : colors.dark
     switch (embeddedNavBar) {
@@ -147,6 +166,13 @@ const Education = ({
               onPress={goBack}
               icon={step === 0 ? <Times color={color} /> : <BackChevron color={color} />}
             />
+            {experimentalSwiper && (
+              <View style={styles.logoContainer}>
+                <Animated.View style={logoAnimatedStyle}>
+                  <Logo height={60} type={LogoTypes.LIGHT} />
+                </Animated.View>
+              </View>
+            )}
           </View>
         )
       case EmbeddedNavBar.Drawer:
@@ -249,7 +275,7 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   top: {
-    paddingLeft: 24,
+    paddingHorizontal: 24,
     paddingTop: 48,
     paddingVertical: 16,
     flexDirection: 'column',
@@ -258,5 +284,9 @@ const styles = StyleSheet.create({
   experimental: {
     height: '50%',
     backgroundColor: colors.greenUI,
+  },
+  logoContainer: {
+    flexGrow: 1,
+    justifyContent: 'flex-end',
   },
 })


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

* Previously, the education screens for Kolektivo Guilder Education, and Account Backup education would depend on a missing branding image element
* Now, the design looks cleaner without one.