### PR TITLE
chore: Make ANG the default currency always

### DIFF
--- a/src/localCurrency/selectors.ts
+++ b/src/localCurrency/selectors.ts
@@ -1,13 +1,8 @@
 import { getRegionCode } from '@celo/utils/lib/phoneNumbers'
 import CountryData from 'country-data'
-import { getCurrencies } from 'react-native-localize'
 import { createSelector } from 'reselect'
 import { e164NumberSelector } from 'src/account/selectors'
-import {
-  LocalCurrencyCode,
-  LocalCurrencySymbol,
-  LOCAL_CURRENCY_CODES,
-} from 'src/localCurrency/consts'
+import { LocalCurrencyCode, LocalCurrencySymbol } from 'src/localCurrency/consts'
 import { RootState } from 'src/redux/reducers'
 import { Currency } from 'src/utils/currencies'
 
@@ -28,16 +23,16 @@ const getDefaultLocalCurrencyCode = createSelector(
     // but the problem is some Android versions don't make it possible to select the appropriate language/country
     // from the device settings.
     // So here we use the country of the phone number
-    const countryCurrencies = e164PhoneNumber
-      ? getCountryCurrencies(e164PhoneNumber)
-      : getCurrencies()
-    const supportedCurrenciesSet = new Set(LOCAL_CURRENCY_CODES)
+    // const countryCurrencies = e164PhoneNumber
+    //   ? getCountryCurrencies(e164PhoneNumber)
+    //   : getCurrencies()
+    // const supportedCurrenciesSet = new Set(LOCAL_CURRENCY_CODES)
 
-    for (const countryCurrency of countryCurrencies) {
-      if (supportedCurrenciesSet.has(countryCurrency as LocalCurrencyCode)) {
-        return countryCurrency as LocalCurrencyCode
-      }
-    }
+    // for (const countryCurrency of countryCurrencies) {
+    //   if (supportedCurrenciesSet.has(countryCurrency as LocalCurrencyCode)) {
+    //     return countryCurrency as LocalCurrencyCode
+    //   }
+    // }
 
     return LocalCurrencyCode.ANG
   }


### PR DESCRIPTION
### Description

Made ANG the default currency no matter the device settings or preferences. Can still be changed in the app afterwards.

### Other changes

_Describe any minor or "drive-by" changes here._

### Tested

_An explanation of how the changes were tested or an explanation as to why they don't need to be._


### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

### Related issues

- Fixes #[issue number here]

### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._