### PR TITLE
(KW-206) User should glance the time of a transaction in their history for a transaction of the same day

### DIFF
--- a/src/transactions/feed/TransferFeedItem.tsx
+++ b/src/transactions/feed/TransferFeedItem.tsx
@@ -34,7 +34,7 @@ function TransferFeedItem({ transfer }: Props) {
 
   const tokenInfo = useTokenInfo(amount.tokenAddress)
   const showTokenAmount = !amount.localAmount && !tokenInfo?.usdPrice
-  const { title, subtitle, recipient, elapsed } = useTransferFeedDetails(transfer)
+  const { title, subtitle, recipient, elapsed, displayTime } = useTransferFeedDetails(transfer)
 
   const colorStyle = new BigNumber(amount.value).isPositive() ? { color: colors.greenUI } : {}
 
@@ -47,7 +47,7 @@ function TransferFeedItem({ transfer }: Props) {
             {title}
           </Text>
           <Text style={styles.subtitle} testID={'TransferFeedItem/subtitle'}>
-            {subtitle} {elapsed}
+            {subtitle} {displayTime || elapsed}
           </Text>
         </View>
         <View style={styles.amountContainer}>

--- a/src/transactions/transferFeedUtils.ts
+++ b/src/transactions/transferFeedUtils.ts
@@ -374,7 +374,8 @@ export function useTransferFeedDetails(transfer: FeedTokenTransfer) {
 
   const daysSince = timeDeltaInDays(Date.now(), timestamp, true)
   const elapsed = t('daysAgo', { days: daysSince })
-  const displayTime = daysSince > 0 ? null : new Date(timestamp).toLocaleTimeString()
+  const displayTime =
+    daysSince > 0 ? null : new Date(timestamp).toLocaleTimeString([], { timeStyle: 'short' })
   return { title, subtitle, recipient, elapsed, displayTime }
 }
 

--- a/src/transactions/transferFeedUtils.ts
+++ b/src/transactions/transferFeedUtils.ts
@@ -372,9 +372,10 @@ export function useTransferFeedDetails(transfer: FeedTokenTransfer) {
     subtitle = t('confirmingTransaction')
   }
 
-  const elapsed = t('daysAgo', { days: timeDeltaInDays(Date.now(), timestamp, true) })
-
-  return { title, subtitle, recipient, elapsed }
+  const daysSince = timeDeltaInDays(Date.now(), timestamp, true)
+  const elapsed = t('daysAgo', { days: daysSince })
+  const displayTime = daysSince > 0 ? null : new Date(timestamp).toLocaleTimeString()
+  return { title, subtitle, recipient, elapsed, displayTime }
 }
 
 export function getTxsFromUserTxQuery(data?: UserTransactionsQuery) {

--- a/src/transactions/transferFeedUtils.ts
+++ b/src/transactions/transferFeedUtils.ts
@@ -375,7 +375,9 @@ export function useTransferFeedDetails(transfer: FeedTokenTransfer) {
   const daysSince = timeDeltaInDays(Date.now(), timestamp, true)
   const elapsed = t('daysAgo', { days: daysSince })
   const displayTime =
-    daysSince > 0 ? null : new Date(timestamp).toLocaleTimeString([], { timeStyle: 'short' })
+    daysSince > 0
+      ? null
+      : new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
   return { title, subtitle, recipient, elapsed, displayTime }
 }
 


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

* All transactions showed "N" days ago, where N >= 0
* Transactions for the same day show the adjusted time of the transaction.

### How others should test

_Does this need to be tested by QA in the next release cycle? If so please give a brief explanation of how to test these changes._

* User should send a transaction and observe that it is marked at the correct time.
* Closing and restarting the app should observe the correct time.
* Changing the phone's time zone manually and restarting the application should observe the correct, adjusted time zone.
