### PR TITLE
Throttle the Vendor service when the App is offline

### DIFF
--- a/src/vendors/saga.ts
+++ b/src/vendors/saga.ts
@@ -1,4 +1,4 @@
-import { call, put, spawn, take } from 'redux-saga/effects'
+import { call, put, take } from 'redux-saga/effects'
 import { fetchAllVendors } from 'src/api/vendors'
 import Logger from 'src/utils/Logger'
 import { Actions, setLoading, setVendors } from 'src/vendors/actions'
@@ -17,6 +17,10 @@ export function* watchFetchVendors(): any {
       vendorsInitialized = true
     } catch (error: any) {
       yield Logger.error('Vendor Saga: ', 'Failed to get vendors', error)
+      // @note The saga may throw an error when offline in any screen,
+      // instead, of querying, the saga should wait until the client
+      // tries to refresh the vendor list.
+      yield take(Actions.FETCH_VENDORS)
     }
   }
 }

--- a/src/vendors/utils.ts
+++ b/src/vendors/utils.ts
@@ -50,8 +50,8 @@ export const formatVendors = (vendorObject: any): Vendors => {
             latitude: Number(latitude),
             longitude: Number(longitude),
           },
-          acceptsGuilder: Boolean(acceptsGuilder),
-          providesGuilder: Boolean(providesGuilder),
+          acceptsGuilder: !!acceptsGuilder,
+          providesGuilder: !!providesGuilder,
           account: account,
         } as Vendor | VendorWithLocation,
       }


### PR DESCRIPTION
### Description

_A few sentences describing the overall effects and goals of the pull request's commits.
What is the current behavior, and what is the updated/expected behavior with this PR?_

When the app is offline, or the vendor service is unreachable, the vendor saga should throttle the request to update the vendor list.

- [x] When offline, the app should only query the vendor service for data intermittently
- [x] When online, the app should only query the vendor service once, and any time the user forces a refresh