### PR TITLE
(ZED-699): Send Modal search input not aligned properly

### DIFF
--- a/src/components/WithTextSearchPasteAware.tsx
+++ b/src/components/WithTextSearchPasteAware.tsx
@@ -21,7 +21,8 @@ export default function withTextSearchPasteAware<P extends TextInputProps>(
           <View style={styles.searchIconContainer}>{iconToUse}</View>
           <WrappedTextInput
             {...this.props}
-            inputStyle={styles.input}
+            style={styles.inputContainer}
+            inputStyle={styles.inputText}
             testID="SearchInput"
             showClearButton={!isPasteIconVisible}
           />
@@ -53,7 +54,10 @@ const styles = StyleSheet.create({
     marginLeft: 17,
     marginRight: 13,
   },
-  input: {
+  inputContainer: {
+    flexGrow: 1,
+  },
+  inputText: {
     paddingVertical: 6,
   },
 })


### PR DESCRIPTION
### Description

The search bar input element in the send modal is center aligned and does not span the entire container, so the edges were not selectable to start typing input. This ensures that the element spans the entire container so it is easier to select.