### PR TITLE
(hotfix): Resolve `unknown account` when signing transactions with a custom signer

### DIFF
--- a/patches/@usecapsule+react-native-wallet+0.1.12.patch
+++ b/patches/@usecapsule+react-native-wallet+0.1.12.patch
@@ -1,0 +1,114 @@
+diff --git a/node_modules/@usecapsule/react-native-wallet/src/CapsuleWallet.ts b/node_modules/@usecapsule/react-native-wallet/src/CapsuleWallet.ts
+index 6ef667f..67be3d8 100644
+--- a/node_modules/@usecapsule/react-native-wallet/src/CapsuleWallet.ts
++++ b/node_modules/@usecapsule/react-native-wallet/src/CapsuleWallet.ts
+@@ -1,16 +1,16 @@
+-import { CeloTx, EncodedTransaction } from '@celo/connect';
+-import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
++import {CeloTx, EncodedTransaction} from '@celo/connect';
++import {EIP712TypedData} from '@celo/utils/lib/sign-typed-data-utils';
+ import * as ethUtil from 'ethereumjs-util';
+-import { ErrorMessages } from './ErrorMessages';
+-import { CapsuleBaseSigner } from './CapsuleSigner';
+-import { SignersStorage } from './SignersStorage';
+-import { SessionStorage } from './SessionStorage';
++import {ErrorMessages} from './ErrorMessages';
++import {CapsuleBaseSigner} from './CapsuleSigner';
++import {SignersStorage} from './SignersStorage';
++import {SessionStorage} from './SessionStorage';
+ import SessionManager from './SessionManager';
+-import { logger } from './Logger';
++import {logger} from './Logger';
+ import userManagementClient from './UserManagementClient';
+-import { KeyType } from './SignerModule';
+-import { KeyContainer } from './KeyContainer';
+-import { requestAndReauthenticate } from './helpers';
++import {KeyType} from './SignerModule';
++import {KeyContainer} from './KeyContainer';
++import {requestAndReauthenticate} from './helpers';
+ 
+ const TAG = 'geth/CapsuleWallet';
+ 
+@@ -149,7 +149,7 @@ export abstract class CapsuleBaseWallet {
+     const address = await signer.generateKeyshare(onRecoveryKeyshare);
+ 
+     logger.info(`${TAG}@addAccount`, `Keyshare succesfully created`);
+-    await this.signersStorage.addAccount(address);
++    await this.signersStorage.addAccountInternal(address);
+     return address;
+   }
+ 
+@@ -194,7 +194,7 @@ export abstract class CapsuleBaseWallet {
+     const address = await signer.importKeyshare(keyshare);
+ 
+     logger.info(`${TAG}@importAccount`, `Keyshare succesfully imported`);
+-    await this.signersStorage.addAccount(address);
++    await this.signersStorage.addAccountInternal(address);
+     return address;
+   }
+ 
+@@ -215,7 +215,7 @@ export abstract class CapsuleBaseWallet {
+     onNewRecoveryKeyshare: (keyshare: string) => void
+   ): Promise<string> {
+     const recoveryKeyshare = KeyContainer.import(rawRecoveryKeyshare);
+-    const { walletId } = recoveryKeyshare;
++    const {walletId} = recoveryKeyshare;
+ 
+     const userId = await this.getUserId();
+     const result = await requestAndReauthenticate(
+@@ -283,11 +283,11 @@ export abstract class CapsuleBaseWallet {
+   ): Promise<string> {
+     logger.info(
+       `${TAG}@signTypedData`,
+-      `Signing typed DATA: ${JSON.stringify({ address, typedData })}`
++      `Signing typed DATA: ${JSON.stringify({address, typedData})}`
+     );
+     const signer = await this.getSigner();
+-    const { v, r, s } = await signer.signTypedData(address, typedData);
+-    logger.info(`${TAG}@signTypedData - result`, { v, r, s });
++    const {v, r, s} = await signer.signTypedData(address, typedData);
++    logger.info(`${TAG}@signTypedData - result`, {v, r, s});
+     return ethUtil.toRpcSig(v, r, s);
+   }
+ 
+@@ -348,4 +348,11 @@ export abstract class CapsuleBaseWallet {
+     await this.initSessionManagerIfNeeded();
+     await this.sessionManager!.refreshSessionIfNeeded();
+   }
++
++  // TEMPORARY
++  public hasAccount(address: string) {
++    !!this.signersStorage
++      .getAccountsSync()
++      .find((add) => add.toLowerCase() === address.toLowerCase());
++  }
+ }
+diff --git a/node_modules/@usecapsule/react-native-wallet/src/SignersStorage.ts b/node_modules/@usecapsule/react-native-wallet/src/SignersStorage.ts
+index d0c297e..08852c6 100644
+--- a/node_modules/@usecapsule/react-native-wallet/src/SignersStorage.ts
++++ b/node_modules/@usecapsule/react-native-wallet/src/SignersStorage.ts
+@@ -1,4 +1,24 @@
+ export abstract class SignersStorage {
++  private syncStorage: string[] | undefined;
++  private async loadToSyncStorage() {
++    this.syncStorage = await this.getAccounts();
++  }
++  public async addAccountInternal(account: string): Promise<void> {
++    await this.addAccount(account);
++    await this.loadToSyncStorage();
++  }
++  constructor() {
++    this.loadToSyncStorage();
++  }
++
++  public getAccountsSync(): string[] {
++    if (!this.syncStorage) {
++      throw new Error('sync storage not loaded yet!');
++    }
++    return this.syncStorage;
++  }
++
+   public abstract addAccount(account: string): Promise<void>;
+   public abstract getAccounts(): Promise<string[]>;
+ }
++

--- a/src/web3/saga.ts
+++ b/src/web3/saga.ts
@@ -26,6 +26,7 @@ import { navigate, navigateToError } from 'src/navigator/NavigationService'
 import { Screens } from 'src/navigator/Screens'
 import {
   CANCELLED_PIN_INPUT,
+  getPassword,
   getPasswordSaga,
   retrieveSignedMessage,
 } from 'src/pincode/authentication'
@@ -250,8 +251,9 @@ export function* createAndAssignCapsuleAccount() {
     try {
       yield call([wallet, wallet.initSessionManagement])
       account = yield call([wallet, wallet.createAccount], transmitRecoveryKeyshare)
-      const passcode: string = yield call(getPasswordSaga, account, false, true)
-      if (!passcode) {
+      try {
+        yield call(getPasswordSaga, account, false, true)
+      } catch (error) {
         yield take(AccountActions.SET_PINCODE_SUCCESS)
       }
       const userKeyshare: string = yield call([wallet, wallet.getKeyshare], account)


### PR DESCRIPTION
### What was done

* Added `patch` of `@usecapsule/react-native-wallet` to include `hasAccount` function provided
* Fixed an error where during `createAndAssignCapsuleWallet`, the `getPasswordSaga` would throw an error and fail wallet initialization